### PR TITLE
Adding search count to lualine

### DIFF
--- a/lua/plugins/ui.lua
+++ b/lua/plugins/ui.lua
@@ -67,6 +67,19 @@ return {
     },
     config = function()
       local git_blame = require('gitblame')
+      vim.o.shortmess = vim.o.shortmess .. "S" -- this is for the search_count function so lua can know this is `lua expression`
+      --function for optimizing the search count 
+      local function search_count()
+        if vim.api.nvim_get_vvar("hlsearch") == 1 then
+          local res = vim.fn.searchcount({ maxcount = 999, timeout = 500 })
+
+          if res.total > 0 then
+            return string.format("%d/%d", res.current, res.total)
+          end
+        end
+
+        return ""
+      end
       require('lualine').setup {
         options = {
           section_separators = '',
@@ -77,7 +90,8 @@ return {
         sections = {
           lualine_c = {
             { git_blame.get_current_blame_text, cond = git_blame.is_blame_text_available }
-          }
+          },
+          lualine_b = {'branch', { search_count, type = "lua_expr" } }
         },
         extensions = { 'nvim-tree' },
       }


### PR DESCRIPTION
Adding search count to lualine with an optimized function. the function used to add more flexibility to the search count.

Reasons for this PR:
- search count is very important and gives context to the search and I can't think of 1 reason why it wouldn't.
- tit doesn't affect the experience of the user because it's unseen until the search starts.

Thank you.