### PR TITLE
Fix 'rigth' typo on line 213 of keymap.lua

### DIFF
--- a/lua/config/keymap.lua
+++ b/lua/config/keymap.lua
@@ -210,7 +210,7 @@ wk.register({
 		n = { "]s", "next" },
 		p = { "[s", "previous" },
 		g = { "zg", "good" },
-		r = { "zg", "rigth" },
+		r = { "zg", "right" },
 		w = { "zw", "wrong" },
 		b = { "zw", "bad" },
 		["?"] = { "<cmd>Telescope spell_suggest<cr>", "suggest" },


### PR DESCRIPTION
Cleaning up a small typo in the `whichkey` binding for spellcheck.