### PR TITLE
Change deprecated tsserver to ts_ls

### DIFF
--- a/lua/plugins/lsp.lua
+++ b/lua/plugins/lsp.lua
@@ -182,7 +182,7 @@ return {
         flags = lsp_flags,
       }
 
-      lspconfig.tsserver.setup {
+      lspconfig.ts_ls.setup {
         capabilities = capabilities,
         flags = lsp_flags,
         filetypes = { 'js', 'javascript', 'typescript', 'ojs' },


### PR DESCRIPTION
The tsserver package changed names to ts_ls, triggering a notification on launch of neovim. This fixes the problem.. 