### PR TITLE
Add chunk eval/move functions and keybindings

### DIFF
--- a/lua/plugins/ui.lua
+++ b/lua/plugins/ui.lua
@@ -130,7 +130,6 @@ return {
     dependencies = { 'nvim-tree/nvim-web-devicons' },
     keys = {
       { '-',          ':Oil<cr>', desc = 'oil' },
-      { '<leader>ef', ':Oil<cr>', desc = 'edit [f]iles' },
     },
     cmd = 'Oil',
   },


### PR DESCRIPTION
I added some functions that send code chunks to the terminal and move to the next chunk, and functions for jumping to the next/prior chunk/eval all above chunks that don't have `#|eval: false` in them, I've found them handy so thought they might be of interest!

I replaced the keybinding for opening Oil for these keymaps (there's still the `-` keybinding from normal mode)